### PR TITLE
add resourcemapWhitespace option for JSON.stringify indent width

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ fis 中对依赖的js 加载，尤其是异步  js，需要一个 js loader。�
 * `obtainStyle` 是否收集 `<style>` 和 `<link>` 内容。（非页面依赖部分）
 * `useInlineMap` 是否将 sourcemap 作为内嵌脚本输出。
 * `resoucemap` 默认为 `/pkg/${filepath}_map.js` 当 `useInLineMap` 为 `false` 的时候有效，用来控制 resourcemap 生成位置。
+* `resourcemapWhitespace` resourcemap缩进宽度, 默认为2.
 * `include` 默认生成的 sourcemap 只会包含异步依赖的 js, 如果想把一批模块化的 js 加入到 sourcemap 中，请参考一下配置：
 
   ```js

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -24,6 +24,7 @@ function Resource(ret, host, opts) {
   this.js = [];
   this.asyncs = [];
   this.calculated = false;
+  this.resourcemapWhitespace = opts.resourcemapWhitespace || 2;
 
   this.ignoreAsync = opts.allInOne && opts.allInOne.includeAsyncs;
 }
@@ -330,7 +331,7 @@ Resource.prototype.buildResourceMap = function() {
     map.pkg = pkg;
   }
 
-  return 'require.resourceMap(' + JSON.stringify({res: res, pkg: pkg}, null, 2) + ');';
+  return 'require.resourceMap(' + JSON.stringify({res: res, pkg: pkg}, null, self.resourcemapWhitespace) + ');';
 };
 
 Resource.prototype.buildAMDPath = function() {
@@ -365,7 +366,7 @@ Resource.prototype.buildAMDPath = function() {
     return '';
   }
 
-  return 'require.config({paths:' + JSON.stringify(paths, null, 2) + '});';
+  return 'require.config({paths:' + JSON.stringify(paths, null, self.resourcemapWhitespace) + '});';
 };
 
 Resource.prototype.buildCMDPath = function() {
@@ -401,7 +402,7 @@ Resource.prototype.buildCMDPath = function() {
   }
 
   // {paths:' + JSON.stringify(paths, null, 2) + '});
-  return 'seajs.config({alias:' + JSON.stringify(paths, null, 2) + '});';
+  return 'seajs.config({alias:' + JSON.stringify(paths, null, self.resourcemapWhitespace) + '});';
 };
 
 Resource.prototype.buildSystemPath = function() {
@@ -450,10 +451,10 @@ Resource.prototype.buildSystemPath = function() {
 
   var configs = [];
   if (!isEmpty(paths)) {
-    configs.push('map:' + JSON.stringify(paths, null, 2));
+    configs.push('map:' + JSON.stringify(paths, null, self.resourcemapWhitespace));
   }
   if (!isEmpty(bundles)) {
-    configs.push('bundles:' + JSON.stringify(bundles, null, 2));
+    configs.push('bundles:' + JSON.stringify(bundles, null, self.resourcemapWhitespace));
   }
 
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -24,7 +24,7 @@ function Resource(ret, host, opts) {
   this.js = [];
   this.asyncs = [];
   this.calculated = false;
-  this.resourcemapWhitespace = opts.resourcemapWhitespace || 2;
+  this.resourcemapWhitespace = 'number' !== typeof opts.resourcemapWhitespace ? 2 : opts.resourcemapWhitespace;
 
   this.ignoreAsync = opts.allInOne && opts.allInOne.includeAsyncs;
 }


### PR DESCRIPTION
由于 fis-optimizer-uglify-js插件对postpackager阶段生成的js不起作用, 所以添加一个选项, 可以在生成resourcemap的时候设置缩进宽度, 默认为0, 即压缩状态节省空间