### PR TITLE
Update pack.js

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -4,7 +4,7 @@
 var common = require('./common.js');
 var SourceMap = require('source-map');
 var _ = fis.util;
-var rSourceMap = /\/\/\#\s*sourceMappingURL[^\n\r]*/ig;
+var rSourceMap = /\/\/\#\s*sourceMappingURL[^\r\n]*(?:\r?\n|$)/i;
 
 module.exports = function(file, resource, ret, opts) {
   var root = fis.project.getProjectPath();


### PR DESCRIPTION
rSourceMap is used to strip the sourcemap embeding in composite js files, so the g flag is not needed, and the extra newline should be added to the pattern, so to remove it with the entire line.