### PR TITLE
可定制化输出目录规则

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ fis 中对依赖的js 加载，尤其是异步  js，需要一个 js loader。�
 
   allInOne 接收对象配置项。
 
+  - 'css, js' 可接受函数, 回传file, 可定制化路径规则, 如:  
+  ```js
+    postpackager: fis.plugin('loader', {
+      allInOne: {
+        js: function (file) {
+          return "/static/js/pages/" + file.filename + "_aio.js";
+        },
+        css: function (file) {
+          return "/static/css/" + file.filename + "_aio.css";
+        }
+      }      
+    })
+  ```
   - `css` all in one 打包后， css 文件的路径规则。默认为 `pkg/${filepath}_aio.css`
   - `js` all in one 打包后， js 文件的路径规则。默认为 `pkg/${filepath}_aio.js`
   - `includeAsyncs` 默认为 false。all in one 打包，是不包含异步依赖的，不过可以通过把此属性设置成 true，包含异步依赖。

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ fis 中对依赖的js 加载，尤其是异步  js，需要一个 js loader。�
     postpackager: fis.plugin('loader', {
       allInOne: {
         js: function (file) {
-          return "/static/js/pages/" + file.filename + "_aio.js";
+          return "/static/js/" + file.filename + "_aio.js";
         },
         css: function (file) {
           return "/static/css/" + file.filename + "_aio.css";

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ fis 中对依赖的js 加载，尤其是异步  js，需要一个 js loader。�
 
   allInOne 接收对象配置项。
 
-  - 'css, js' 可接受函数, 回传file, 可定制化路径规则, 如:  
+  - `css, js` 可接受函数, 回传file, 可定制化路径规则, 如:  
   ```js
     postpackager: fis.plugin('loader', {
       allInOne: {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -102,11 +102,7 @@ module.exports = function(file, resource, ret, opts) {
     }
 
     function _pack() {
-      var filepath = common.tokenizePath(getFileTpl(fileTpl, file), {
-        filepath: file.subpath,
-        filename: file.filename,
-        hash: file.getHash()
-      });
+      var filepath = getFilepath(fileTpl, file);
 
       if (index>1) {
         filepath = filepath.replace(/\.([^\.]+)$/i, function(ext) {
@@ -207,12 +203,16 @@ module.exports = function(file, resource, ret, opts) {
     }
     
     //定制化目录处理, 可以传函数进来
-    function getFileTpl(fun, file) {
+    function getFilepath(fun, file) {
   		if(typeof(fun) == "function"){
   			return fun(file);
   		}
-  		
-  		return fun;
+  
+  		return common.tokenizePath(fun, {
+  			filepath: file.subpath,
+  			filename: file.filename,
+  			hash: file.getHash()
+  		});
   	}
 
     function contents2sourceNodes(content, filename) {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -102,7 +102,7 @@ module.exports = function(file, resource, ret, opts) {
     }
 
     function _pack() {
-      var filepath = common.tokenizePath(fileTpl, {
+      var filepath = common.tokenizePath(getFileTpl(fileTpl, file), {
         filepath: file.subpath,
         filename: file.filename,
         hash: file.getHash()
@@ -205,6 +205,15 @@ module.exports = function(file, resource, ret, opts) {
 
       return null;
     }
+    
+    //定制化目录处理, 可以传函数进来
+    function getFileTpl(fun, file) {
+  		if(typeof(fun) == "function"){
+  			return fun(file);
+  		}
+  		
+  		return fun;
+  	}
 
     function contents2sourceNodes(content, filename) {
       var chunks = [];


### PR DESCRIPTION
 css, js 可接受函数, 回传file, 可定制化路径规则, 如:  
    postpackager: fis.plugin('loader', {
      allInOne: {
        js: function (file) {
          return "/static/js/" + file.filename + "_aio.js";
        },
        css: function (file) {
          return "/static/css/" + file.filename + "_aio.css";
        }
      }      
   })