### PR TITLE
修改css的placeholder的替换规则

### DIFF
--- a/lib/lang/html.js
+++ b/lib/lang/html.js
@@ -390,7 +390,7 @@ function process(file, resource, opts) {
       }
     }
 
-    content = content.replace(opts.stylePlaceHolder, '    ' + css.join('\n    '));
+    content = content.replace(new RegExp(opts.stylePlaceHolder, 'gm'), '    ' + css.join('\n    '));
   }
 
   if (~content.indexOf(opts.scriptPlaceHolder)) {


### PR DESCRIPTION
将<!--STYLE_PLACEHOLDER-->出现的地方全部替换为css